### PR TITLE
Use the libvirt connection uri in virt-viewer too

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -24,6 +24,18 @@ Within each of the above directories, you need to provide the files:
 You can find these files within the relevant Windows installation
 `.iso` images.
 
+For example, you can extract those files with:
+
+```
+7z x \
+    -oimages/win7/x64 \
+    your-windows-7.iso \
+    bootmgr \
+    boot/bcd \
+    boot/boot.sdi \
+    sources/boot.wim
+```
+
 Running tests
 -------------
 

--- a/test/README.md
+++ b/test/README.md
@@ -40,7 +40,7 @@ At the end of each test run, the `out` directory will include a debug
 iPXE boot ROM
 -------------
 
-Most Linux distributionss provide iPXE boot ROMs for BIOS virtual
+Most Linux distributions provide iPXE boot ROMs for BIOS virtual
 machines, but may not provide a suitable boot ROM for UEFI virtual
 machines.
 

--- a/test/testwimboot
+++ b/test/testwimboot
@@ -228,8 +228,11 @@ for test_file in args.test:
 
     # Launch interactive viewer, if requested
     if args.interactive:
-        viewer = subprocess.Popen(['virt-viewer', '--attach',
-                                   '--id', str(vm.ID())])
+        viewer = subprocess.Popen([
+            'virt-viewer',
+            '--connect', args.connection,
+            '--attach',
+            '--id', str(vm.ID())])
     else:
         viewer = None
 


### PR DESCRIPTION
This is needed in my Ubuntu 20.04 because the default libvirt uri is `qemu:///system` instead of the default `testwimboot` `qemu:///session`.