### PR TITLE
Omit initrd region descriptor if located above 4GB

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -492,6 +492,10 @@ int main ( void ) {
 	bootapps.regions[INITRD_REGION].num_pages =
 		page_len ( initrd, initrd + initrd_len );
 
+	/* Omit initrd region descriptor if located above 4GB */
+	if ( initrd_phys >= ADDR_4GB )
+		bootapps.memory.num_regions--;
+
 	/* Disable paging */
 	disable_paging ( &state );
 

--- a/test/highmem_x86.yml
+++ b/test/highmem_x86.yml
@@ -1,0 +1,8 @@
+name: Windows 10 (High RAM, 32-bit)
+version: win10
+arch: x86
+memory: 5120
+logcheck:
+  - 'Found initrd at \[0x[0-9a-f]{8},0x[8-9a-f][0-9a-f]{7}\)'
+  - 'Placing initrd at \[0x[0-9a-f]{8},0x[0-7][0-9a-f]{7}\)'
+  - 'Placing initrd at physical \[0x[1-9a-f][0-9a-f]{8,},'


### PR DESCRIPTION
The 32-bit version of winload.exe will attempt to set up identity
mappings for all addresses described as boot application regions,
including the initrd region.  When the initrd is placed higher than
4GB, identity mapping is impossible since 32-bit virtual addresses
cannot exceed 4GB.

The implementing code in winload!MmMapPhysicalAddress attempts the
mapping by calling winload!MmArchTranslateVirtualAddress, which takes
the address as a 32-bit parameter.  The address is therefore silently
truncated to 32 bits, causing winload!MmArchTranslateVirtualAddress to
succeed in identity-mapping the wrong address.

In Windows 7 and earlier, this will cause a harmless mapping of an
untouched area of memory, provided that the truncated address range
does not overlap with any other address ranges in use.

In Windows 8 and later, there is a subsequent validity check within
winload!MmMapPhysicalAddress that will fail if the mapped address does
not equal the requested (64-bit) address.  This failed validity check
will lead to a "Windows failed to start" error with status 0xc000000d
and info "An unexpected error has occurred".

Disassembly of bootmgr.exe shows that it is a 32-bit application (even
on 64-bit versions of Windows) with support only for building 64-bit
page tables and switching to long mode immediately before transferring
control to winload.exe.  Experiments confirm that bootmgr.exe will not
modify any memory above 4GB.

The virtual files provided by wimboot are fully consumed prior to the
handover from bootmgr.exe to winload.exe.  The subsequent accesses to
the virtual disk by winload.exe request only filesystem structures
such as the MBR, VBR, FAT, FSInfo, and some directory listings.  These
requests can all be satisfied without requiring access to the initrd.

It should therefore be safe to omit the initrd region entirely from
the boot application descriptor when the initrd is located above 4GB,
since neither bootmgr.exe nor winload.exe would modify it before
wimboot has finished using it.

Fixes: #15 