### PR TITLE
[cmdline] Fix debug printing of command line

### DIFF
--- a/src/cmdline.c
+++ b/src/cmdline.c
@@ -66,6 +66,7 @@ void process_cmdline ( char *cmdline ) {
 	char *key;
 	char *value;
 	char *endp;
+	char chr;
 
 	/* Do nothing if we have no command line */
 	if ( ( cmdline == NULL ) || ( cmdline[0] == '\0' ) )
@@ -81,11 +82,11 @@ void process_cmdline ( char *cmdline ) {
 		/* Find value (if any) and end of this argument */
 		key = tmp;
 		value = NULL;
-		while ( *tmp ) {
-			if ( isspace ( *tmp ) ) {
+		while ( ( chr = *tmp ) ) {
+			if ( isspace ( chr ) ) {
 				*(tmp++) = '\0';
 				break;
-			} else if ( *tmp == '=' ) {
+			} else if ( ( chr == '=' ) && ( ! value ) ) {
 				*(tmp++) = '\0';
 				value = tmp;
 			} else {
@@ -124,6 +125,12 @@ void process_cmdline ( char *cmdline ) {
 			die ( "Unrecognised argument \"%s%s%s\"\n", key,
 			      ( value ? "=" : "" ), ( value ? value : "" ) );
 		}
+
+		/* Undo modifications to command line */
+		if ( chr )
+			tmp[-1] = chr;
+		if ( value )
+			value[-1] = '=';
 	}
 
 	/* Show command line (after parsing "quiet" option) */


### PR DESCRIPTION
Commit 9c576c7 ("[cmdline] Add "quiet" option to suppress debug output") deferred the printing of the command line until after parsing the "quiet" command-line argument, in order to allow the printing of the command line to itself be inhibited.  Since the act of parsing the command line will replace the argument separator characters with NULs, this has the unwanted side effect of causing only the first command-line parameter to be printed.

Fix by restoring the characters that were replaced by NULs during parsing.

Fixes: #41 

Signed-off-by: Michael Brown <mbrown@fensystems.co.uk>