### PR TITLE
[patch] Fix use of "index=N" when no injected files are present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Changelog
 
 - Fix building with GCC 12
 
+- Fix use of `index=N` when no injected files are present.
+
 ## [v2.7.4] 2022-01-20
 
 - Add [Secure Boot Advanced Targeting (SBAT)][sbat] metadata.

--- a/src/wimpatch.c
+++ b/src/wimpatch.c
@@ -683,6 +683,10 @@ static int wim_construct_patch ( struct vdisk_file *file,
 				   &patch->boot ) ) != 0 )
 		return rc;
 
+	/* Update boot image metadata in patched header, if applicable */
+	if ( boot_index )
+		memcpy ( boot, &patch->boot, sizeof ( *boot ) );
+
 	/* Record original boot index */
 	patch->boot_index = patch->header.boot_index;
 


### PR DESCRIPTION
Commit 7f42b27 ("[patch] Patch the WIM image to include additional files") introduced a hidden bug: if the "index=N" parameter is used to modify the boot index but no injected files are present, then nothing will ever update the boot image metadata within the stored patched WIM header.  (When injected files are present, the injection code will subsequently update both the boot index and the boot image metadata as part of the injection mechanism.)

This bug remained hidden for many years.  Partly because not many people use the "index=N" feature, and partly because under UEFI the presence of the "wimboot" binary itself within the virtual filesystem exposed by iPXE meant that there would always be at least one injected file, and so the faulty code path would not be taken.

Commit ac4190a ("[patch] Avoid patching wimboot binary itself into image") fixed the unintended injection of the "wimboot" binary itself, thereby revealing the underlying bug in the existing code.

Fix by explicitly updating the boot image metadata within the stored patched WIM header, before considering the existence of injected files.

Reported-by: Anatoli Alexandrov <tony_alexandrov@hotmail.com>
Tested-by: Anatoli Alexandrov <tony_alexandrov@hotmail.com>
Signed-off-by: Michael Brown <mbrown@fensystems.co.uk>