### PR TITLE
Upgraded GitHub Actions to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install packages
         run: |
           sudo apt update
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install packages
         run: |
           sudo apt update

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install packages
         run: |
           sudo apt update

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
 
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install packages
         run: |

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -54,7 +54,7 @@ jobs:
           echo "hash=${{ hashFiles('.rsync.list') }}" >> $GITHUB_OUTPUT
 
       - name: Cache images
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: test/images
           key: ${{ secrets.IMAGES_CACHE_KEY }}-${{ steps.key.outputs.hash }}
@@ -79,7 +79,7 @@ jobs:
     steps:
 
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install packages
         run: |
@@ -96,7 +96,7 @@ jobs:
           make
 
       - name: Fetch images
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: test/images
           key: ${{ secrets.IMAGES_CACHE_KEY }}-${{ needs.cache.outputs.hash }}
@@ -107,7 +107,7 @@ jobs:
 
       - name: Upload outputs
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: qa-results
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
 
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Get version
         run: |


### PR DESCRIPTION
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20